### PR TITLE
add jacoco ((Java Code Coverage)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -78,7 +78,27 @@
                     </excludes>
                 </configuration>
             </plugin>
-        </plugins>
+            <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.12</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>report</id>
+                    <phase>test</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+
+    </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
Beschreibung von jacoco: JaCoCo ist ein Werkzeug zur Codeabdeckung für Java. Es misst, wie viel deines Codes durch Tests abgedeckt wird und zeigt ungetestete Code-Bereiche auf. Mit JaCoCo kannst du die Qualität deiner Tests verbessern, indem du sicherstellst, dass alle wichtigen Teile des Codes getestet werden. Es bietet Berichte in verschiedenen Formaten (HTML, XML, CSV), um die Testabdeckung zu visualisieren und zu optimieren.